### PR TITLE
Speed up ring animation

### DIFF
--- a/screens/components/AnimatedRing.js
+++ b/screens/components/AnimatedRing.js
@@ -29,7 +29,7 @@ export default function AnimatedRing({ delay, scale }) {
       delay,
       withRepeat(
         withTiming(1, {
-          duration: 3000,
+          duration: 2000,
         }),
         -1,
         false

--- a/screens/components/Recorder.js
+++ b/screens/components/Recorder.js
@@ -249,7 +249,12 @@ export default function Recorder(props) {
                       <>
                         <AnimatedRing
                           delay={0}
-                          scale={0.5}
+                          scale={2}
+                          isRecording={isRecording}
+                        />
+                        <AnimatedRing
+                          delay={500}
+                          scale={1}
                           isRecording={isRecording}
                         />
                         <AnimatedRing
@@ -258,12 +263,7 @@ export default function Recorder(props) {
                           isRecording={isRecording}
                         />
                         <AnimatedRing
-                          delay={2000}
-                          scale={1}
-                          isRecording={isRecording}
-                        />
-                        <AnimatedRing
-                          delay={3000}
+                          delay={1500}
                           scale={1}
                           isRecording={isRecording}
                         />


### PR DESCRIPTION
Speeded up microphone recording animation speed as we only have less than 10 seconds to demonstrate that feature.

Issue: #94 